### PR TITLE
Navigathema blank scene is now unloaded when scene loaded

### DIFF
--- a/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneIdentifier/NavigathenaBlankSceneIdentifier.cs
+++ b/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneIdentifier/NavigathenaBlankSceneIdentifier.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine.SceneManagement;
+
+namespace MackySoft.Navigathena.SceneManagement
+{
+	internal sealed class NavigathenaBlankSceneIdentifier : ISceneIdentifier
+	{
+
+		public static readonly NavigathenaBlankSceneIdentifier Instance = new NavigathenaBlankSceneIdentifier();
+
+		public ISceneHandle CreateHandle ()
+		{
+			return NavigathenaBlankSceneHandle.Instance;
+		}
+
+		sealed class NavigathenaBlankSceneHandle : ISceneHandle
+		{
+
+			public static readonly NavigathenaBlankSceneHandle Instance = new NavigathenaBlankSceneHandle();
+
+			const string kSceneName = "Navigathena Blank";
+
+			public UniTask<Scene> Load (IProgress<float> progress = null, CancellationToken cancellationToken = default)
+			{
+				if (SceneManager.GetSceneByName(kSceneName).IsValid())
+				{
+					return UniTask.FromResult(SceneManager.GetSceneByName(kSceneName));
+				}
+				return UniTask.FromResult(SceneManager.CreateScene(kSceneName));
+			}
+
+			public async UniTask Unload (IProgress<float> progress = null, CancellationToken cancellationToken = default)
+			{
+				Scene scene = SceneManager.GetSceneByName(kSceneName);
+				if (!scene.isLoaded && !scene.IsValid())
+				{
+					return;
+				}
+
+				await SceneManager.UnloadSceneAsync(kSceneName)
+					.ToUniTask(progress, cancellationToken: cancellationToken);
+			}
+		}
+	}
+}

--- a/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneIdentifier/NavigathenaBlankSceneIdentifier.cs.meta
+++ b/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneIdentifier/NavigathenaBlankSceneIdentifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b86bf327ceec0046a828210b98f04f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneNavigator/StandardSceneNavigator.cs
+++ b/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneNavigator/StandardSceneNavigator.cs
@@ -327,7 +327,7 @@ namespace MackySoft.Navigathena.SceneManagement
 				// NOTE: If the current scene is the only scene, create an empty scene to prevent an exception from being thrown when unloading.
 				if (SceneManager.sceneCount < 2)
 				{
-					SceneManager.CreateScene("Navigathena Blank");
+					await NavigathenaBlankSceneIdentifier.Instance.CreateHandle().Load(cancellationToken: cancellationToken);
 				}
 
 				await m_CurrentSceneState.Value.Handle.Unload(m_SceneProgressFactory.CreateProgress(progressDataStore, progress), cancellationToken);

--- a/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneNavigatorHelper.cs
+++ b/Assets/MackySoft/MackySoft.Navigathena/Runtime/SceneManagement/SceneNavigatorHelper.cs
@@ -67,6 +67,9 @@ namespace MackySoft.Navigathena.SceneManagement.Utilities
 			Scene loadedScene = await sceneHandle.Load(sceneProgressFactory.CreateProgress(progressDataStore, progress), cancellationToken);
 			cancellationToken.ThrowIfCancellationRequested();
 
+			await NavigathenaBlankSceneIdentifier.Instance.CreateHandle().Unload(cancellationToken: cancellationToken);
+			cancellationToken.ThrowIfCancellationRequested();
+
 			var sceneEntryPoint = loadedScene.GetComponentInScene<ISceneEntryPoint>(true);
 			return new SceneState(scene, sceneHandle, sceneEntryPoint); 
 		}


### PR DESCRIPTION
If a blank scene is created by Navigathena when there is only one scene, unloading the previous scene will cause the active scene to switch to the blank scene.
As a solution to this problem, a method was proposed to make the scene loaded by Navigathena the active scene. #15 

However, in principle, the active scene should be managed by the user, not Navigathena, so the solution is to always unload the blank scene and only switch the active scene in the above case.